### PR TITLE
build list for array instead Set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynameh",
-  "version": "2.10.3",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/requestBuilder.test.ts
+++ b/src/requestBuilder.test.ts
@@ -28,12 +28,26 @@ describe("requestBuilder", () => {
             chai.assert.deepEqual(serialized, {B: "SGVsbG8gV29ybGQ="});
         });
 
-        it("serializes an array of Buffers", () => {
+        it("serializes an array of Numbers", () => {
             const serialized = buildRequestPutItem(defaultTableSchema, [
+                2, 
+                4,
+            ]);
+            chai.assert.deepEqual(serialized, {
+                L: [
+                    {N: "2"},
+                    {N: "4"}   
+                ]
+            });
+        });
+
+
+        it("serializes an Set of Buffers", () => {
+            const serialized = buildRequestPutItem(defaultTableSchema, new Set([
                 Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64]),
                 Buffer.from([0x4a, 0x65, 0x66, 0x66, 0x47, 0x20, 0x77, 0x61, 0x73, 0x20, 0x68, 0x65, 0x72, 0x65]),
                 Buffer.from([0x6b, 0x77, 0x79, 0x6a, 0x69, 0x62, 0x6f])
-            ]);
+            ]));
             chai.assert.deepEqual(serialized, {
                 BS: [
                     "SGVsbG8gV29ybGQ=",
@@ -43,12 +57,12 @@ describe("requestBuilder", () => {
             });
         });
 
-        it("serializes an array of Uint8Arrays", () => {
-            const serialized = buildRequestPutItem(defaultTableSchema, [
+        it("serializes an Set of Uint8Arrays", () => {
+            const serialized = buildRequestPutItem(defaultTableSchema, new Set([
                 new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64]),
                 new Uint8Array([0x4a, 0x65, 0x66, 0x66, 0x47, 0x20, 0x77, 0x61, 0x73, 0x20, 0x68, 0x65, 0x72, 0x65]),
                 new Uint8Array([0x6b, 0x77, 0x79, 0x6a, 0x69, 0x62, 0x6f])
-            ]);
+            ]));
             chai.assert.deepEqual(serialized, {
                 BS: [
                     "SGVsbG8gV29ybGQ=",

--- a/src/requestBuilder.ts
+++ b/src/requestBuilder.ts
@@ -47,22 +47,26 @@ export function buildRequestPutItem(tableSchema: TableSchema, item: any): aws.Dy
                 } else {
                     return {S: item.toISOString()};
                 }
-            } else if (Array.isArray(item)) {
-                if (item.length > 0) {
-                    const firstItemType = typeof item[0];
-                    if (firstItemType === "string" && item.every(x => typeof x === "string")) {
-                        return {SS: item.map(s => s.toString())};
+            }
+            else if(item instanceof Set){
+                if (item.size > 0) {
+                    const items = Array.from(item);
+                    
+                    if (items.every(x => typeof x === "string")) {
+                        return {SS: items.map(s => s.toString())};
                     }
-                    if (firstItemType === "number" && item.every(x => typeof x === "number")) {
-                        return {NS: item.map(n => n.toString())};
+                    if (items.every(x => typeof x === "number")) {
+                        return {NS: items.map(n => n.toString())};
                     }
-                    if (firstItemType === "object" && item.every(x => x instanceof Buffer)) {
-                        return {BS: item.map(b => b.toString("base64"))};
+                    if (items.every(x => x instanceof Buffer)) {
+                        return {BS: items.map(b => b.toString("base64"))};
                     }
-                    if (firstItemType === "object" && item.every(x => x instanceof Uint8Array)) {
-                        return {BS: item.map(b => Buffer.from(b).toString("base64"))};
+                    if (items.every(x => x instanceof Uint8Array)) {
+                        return {BS: items.map(b => Buffer.from(b).toString("base64"))};
                     }
                 }
+            } 
+            else if (Array.isArray(item)) {
                 return {L: item.map(i => buildRequestPutItem(tableSchema, i))};
             } else {
                 const valueMap: any = {};


### PR DESCRIPTION
#11 Change builder to use L for array instead of Set types.  When object is instance of Set then use the same logic as previously. 

I am not sure what should be done for empty Set. 